### PR TITLE
feat : 이메일 양식 html 추가 및 백엔드 프론트 연결

### DIFF
--- a/moodiary/src/main/java/com/clover/moodiary/user/command/repository/PasswordResetTokenRepository.java
+++ b/moodiary/src/main/java/com/clover/moodiary/user/command/repository/PasswordResetTokenRepository.java
@@ -6,6 +6,8 @@ import com.clover.moodiary.user.command.entity.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -16,5 +18,6 @@ public interface PasswordResetTokenRepository extends JpaRepository<PasswordRese
 
 	@Modifying
 	@Transactional
-	void deleteAllByUser(User user);
+	@Query("DELETE FROM PasswordResetToken t WHERE t.user = :user")
+	void deleteAllByUser(@Param("user") User user);
 }

--- a/moodiary/src/main/java/com/clover/moodiary/user/command/service/UserCommandServiceImpl.java
+++ b/moodiary/src/main/java/com/clover/moodiary/user/command/service/UserCommandServiceImpl.java
@@ -10,6 +10,8 @@ import com.clover.moodiary.user.command.repository.UserRepository;
 import com.clover.moodiary.user.command.service.UserCommandService;
 import com.clover.moodiary.user.command.util.JwtUtil;
 import com.clover.moodiary.user.command.util.MailUtil;
+
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Primary;
@@ -94,10 +96,34 @@ public class UserCommandServiceImpl implements UserCommandService {
 			.build();
 		tokenRepo.save(prt);
 
-		String resetLink = "http://localhost:8080/user/command/reset-password?token=" + newToken;
-		mailUtil.sendEmail(u.getEmail(),
+		String resetLink = "http://localhost:5173/reset-password?token=" + newToken;
+
+		String htmlBody = """
+				<div style="font-family: 'Arial', sans-serif; padding: 20px; background-color: #fff7ee;">
+					<h2 style="color: #A17C59;">[Moodiary] 비밀번호 재설정 안내</h2>
+					<p>안녕하세요,<br>아래 버튼을 클릭하여 비밀번호를 재설정해 주세요.</p>
+					<a href="%s" style="
+						display: inline-block;
+						padding: 12px 24px;
+						margin-top: 16px;
+						background-color: #A17C59;
+						color: white;
+						text-decoration: none;
+						font-weight: bold;
+						border-radius: 8px;">
+						🔐 비밀번호 재설정
+					</a>
+					<p style="margin-top: 20px; font-size: 12px; color: #888;">
+						※ 만약 버튼이 동작하지 않는다면 아래 링크를 복사해 브라우저에 붙여넣기 해 주세요:<br>
+						<a href="%s">%s</a>
+					</p>
+				</div>
+			""".formatted(resetLink, resetLink, resetLink);
+
+		mailUtil.sendEmail(
+			u.getEmail(),
 			"[Moodiary] 비밀번호 재설정 안내",
-			"아래 링크를 클릭하여 비밀번호를 재설정해 주세요:\n" + resetLink
+			htmlBody
 		);
 	}
 
@@ -122,9 +148,12 @@ public class UserCommandServiceImpl implements UserCommandService {
 	public void updateUser(UpdateUserRequest dto) {
 		User u = userRepo.findById(dto.getId())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
-		if (dto.getName() != null)        u.setName(dto.getName());
-		if (dto.getEmail() != null)       u.setEmail(dto.getEmail());
-		if (dto.getPhoneNumber() != null) u.setPhoneNumber(dto.getPhoneNumber());
+		if (dto.getName() != null)
+			u.setName(dto.getName());
+		if (dto.getEmail() != null)
+			u.setEmail(dto.getEmail());
+		if (dto.getPhoneNumber() != null)
+			u.setPhoneNumber(dto.getPhoneNumber());
 		if (dto.getNewPassword() != null) {
 			u.setPassword(passwordEncoder.encode(dto.getNewPassword()));
 		}

--- a/moodiary/src/main/java/com/clover/moodiary/user/command/util/MailUtil.java
+++ b/moodiary/src/main/java/com/clover/moodiary/user/command/util/MailUtil.java
@@ -1,14 +1,14 @@
-// com.clover.moodiary.user.command.util/MailUtil.java
 package com.clover.moodiary.user.command.util;
 
 import java.io.UnsupportedEncodingException;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -18,20 +18,16 @@ public class MailUtil {
 	public void sendEmail(String to, String subject, String body) {
 		try {
 			MimeMessage message = mailSender.createMimeMessage();
-			// 두번째 파라미터는 multipart 여부, 세번째가 인코딩
 			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
 			helper.setTo(to);
 			helper.setSubject(subject);
-			helper.setText(body, true);
-
+			helper.setText("<html><body>" + body + "</body></html>", true);
 			helper.setFrom("rhtjddus0502@naver.com", "Moodiary");
 
 			mailSender.send(message);
-		} catch (MessagingException e) {
+		} catch (MessagingException | UnsupportedEncodingException e) {
 			throw new RuntimeException("메일 발송에 실패했습니다.", e);
-		} catch (UnsupportedEncodingException e) {
-			throw new RuntimeException(e);
 		}
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close 
#55 
#54 

## 📝작업 내용

> 이메일 받을시 양식 html 추가
> localhost로 내부 postman 확인용 uri에서 실제 프론트화면 페이지 uri로 변경

### 스크린샷 (선택)
![재설정](https://github.com/user-attachments/assets/a85aaf1d-bf0d-4617-b1b5-1e8e03192bf3)
![메일양식](https://github.com/user-attachments/assets/a0e2fb6e-042c-4ecd-86b0-7c24c1fa89b7)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
